### PR TITLE
12h cooldown on t.tag all instead of 24h 

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -82,7 +82,7 @@ class TagCommands(commands.Cog, name="Tags"):
             await ctx.send(page)
 
     @tag.command()
-    @commands.cooldown(1, 3600*24, commands.BucketType.user)
+    @commands.cooldown(1, 60*60*12, commands.BucketType.user)
     async def all(self, ctx: commands.Context):
         """List all existing tags alphabetically ordered and sends them in DMs."""
         records = await self.bot.db.fetch(


### PR DESCRIPTION
12h cooldown on t.tag all instead of 24h bcs 24h is excessive and so if the command has a bug people (like me) won’t have to wait a whole day but only half a day which is way better than 24h. 
