### PR TITLE
Correct t.tag all formatting

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -93,8 +93,9 @@ class TagCommands(commands.Cog, name="Tags"):
         if not records:
             return await ctx.send("This server doesn't have any tags.")
 
+        await ctx.author.send(f"***{len(records)} tags found on this server.***")
+
         pager = commands.Paginator()
-        pager.add_line(f"**{len(records)} tags found on this server.**")
 
         for record in records:
             pager.add_line(line=record["name"])


### PR DESCRIPTION
Before it sent 
```
**{n} tags found on this server.**
...
```
But now it will send
***{n} tags found on this server.***
```
...
```