### PR TITLE
Delete bot messages and techwithtim commands

### DIFF
--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -169,8 +169,13 @@ class Commands(commands.Cog):
         for page in pages:
             page = page.replace("`", "`\u200b")
             await ctx.send(f'```py\n{page}```')
-
-    @commands.command(name='website', aliases=['web'])
+    
+    @commands.group(name='tim', aliases=['twt'])
+    async def techwithtim(self, ctx):
+        """Group of commands that have to do with Tim's stuff"""
+        pass # Idk what to send lol
+    
+    @techwithtim.command(name='website', aliases=['web'])
     async def web_(self, ctx):
         """Get the link to Tims website!"""
         embed = discord.Embed(title="Tim's Website", description="[Visit the website!](https://techwithtim.net/)")
@@ -185,7 +190,7 @@ class Commands(commands.Cog):
         await ctx.message.delete()
         await ctx.send(embed=embed)
 
-    @commands.command()
+    @techwithtim.command()
     async def twitter(self, ctx):
         """View Tims Twitter"""
         embed = discord.Embed(title="Tech With Tim Twitter!",
@@ -193,7 +198,7 @@ class Commands(commands.Cog):
         await ctx.message.delete()
         await ctx.send(embed=embed)
 
-    @commands.command(name='instagram', aliases=['insta'])
+    @techwithtim.command(name='instagram', aliases=['insta'])
     async def insta_(self, ctx):
         """View Tims Instagram"""
         embed = discord.Embed(title="Tech With Tim Instagram!",

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 
 import datetime
 
+from .utils.checks import is_mod
 
 def setup(bot: commands.Bot):
     bot.add_cog(Moderation(bot=bot))
@@ -11,6 +12,12 @@ def setup(bot: commands.Bot):
 class Moderation(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+        
+    @commands.Cog.listener()
+    async def on_reaction_add(self, reaction:discord.Reaction, user:discord.Member):
+        if reaction.message.author != self.bot.user and is_mod(user) and 'x' in str(reaction.emoji.name).lower():
+            await reaction.message.delete()
+        
 
     @property
     def report_channel(self):


### PR DESCRIPTION
I just grouped Tim's social media commands as subcommand to `tim`. (But idk what to do for the main command lol)

I also made it so that staff can delete bot messages by reacting ❌ or something with 'x'. I know that this isn't necessary but I had an idea where people (if there are enough people that react) it will also delete messages... (I can't go on discord so I just decided to put my changes here so.... talk lol)