### PR TITLE
removing the extra space in the help embed for mobile users

### DIFF
--- a/cogs/_help.py
+++ b/cogs/_help.py
@@ -30,10 +30,9 @@ class Help(commands.HelpCommand):
         return 'No Category'
 
     def get_opening_note(self) -> str:
-        return f"""A discord bot.
-                   Use **`{self.clean_prefix}help "command name"`** for more info on a command
-                   You can also use **`{self.clean_prefix}help "category name"`** for more info on a category
-                """
+        return 'A discord bot.\n'\
+                f'Use **`{self.clean_prefix}help "command name"`** for more info on a command\n'\
+                f'You can also use **`{self.clean_prefix}help "category name"`** for more info on a category\n'
 
     @staticmethod
     def command_or_group(*obj):


### PR DESCRIPTION
Removing the extra space in the help embed which comes only in mobile view. 


![photo_2020-10-02_10-56-42](https://user-images.githubusercontent.com/59825803/94890865-25c5dc80-049e-11eb-99c4-cbc4f66d91d3.jpg)
