### PR TITLE
Center invite image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,6 @@
 * When you are done with a feature open a pull request.
 * If you have any questions contact us in our discord server.
 
-[![Invitation link](https://discord.com/api/guilds/501090983539245061/widget.png?style=banner4)](https://discord.gg/twt)
+<p align="center">
+  <a href="https://discord.gg/twt"><img src="https://discord.com/api/guilds/501090983539245061/widget.png?style=banner4" alt="Invitation link" title="Invitation link" /></a>
+</p>


### PR DESCRIPTION
It looked weird being on the left and not the center.
It has to be a <p> tag wrapping it for some reason.
The <a> tag makes it clickable.
It keeps the alt text for if the image doesn't load, and also added the title attribute (which can be turned off if ya don't want it)
Based off of https://gist.github.com/DavidWells/7d2e0e1bc78f4ac59a123ddf8b74932d