### PR TITLE
fix whitespace issue in tag create command

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -52,7 +52,7 @@ class TagCommands(commands.Cog, name="Tags"):
 
     @tag.command()
     @is_engineer_check()
-    async def create(self, ctx, name: lambda inp: inp.lower(), *, text: str):
+    async def create(self, ctx, name: lambda inp: inp.lower().strip(), *, text: str):
         """Create a new tag."""
         name = await commands.clean_content().convert(ctx=ctx, argument=name)
         text = await commands.clean_content().convert(ctx=ctx, argument=text)


### PR DESCRIPTION
allows non-triggerable tags by adding whitespace e.g.
t.tag create " test" abc

it's like 2am idk if this is a proper fix im tired af