### PR TITLE
Add filetype to submission embeds in challenges

### DIFF
--- a/cogs/challenges.py
+++ b/cogs/challenges.py
@@ -57,7 +57,7 @@ class ChallengeHandler(commands.Cog):
                 if not attach:
                     msg = (
                         f"{message.author.mention} make sure to __upload a "
-                        f"python file__ that only includes the code required "
+                        f"file__ that only includes the code required "
                         f"for the challenge!"
                     )
                     return await message.channel.send(msg, delete_after=10.0)

--- a/cogs/challenges.py
+++ b/cogs/challenges.py
@@ -64,7 +64,7 @@ class ChallengeHandler(commands.Cog):
 
                 filetype = attach.filename.split(".")[-1]
 
-                if len(filetype) > 4 or len(filetype) == 4:  # Most filetypes are 2-3 chars, 4 just to be safe
+                if len(filetype) > 4 or len(filetype) == 0:  # Most filetypes are 2-3 chars, 4 just to be safe
                     return await message.channel.send(
                         "Please upload a file with a __non-empty file extension shorter than 5 chars__!",
                         delete_after=10.0,

--- a/cogs/challenges.py
+++ b/cogs/challenges.py
@@ -62,8 +62,16 @@ class ChallengeHandler(commands.Cog):
                     )
                     return await message.channel.send(msg, delete_after=10.0)
 
+                filetype = attach.filename.split(".")[-1]
+
+                if len(filetype) > 4:  # Most filetypes are 2-3 chars, 4 just to be safe
+                    return await message.channel.send(
+                        "Please upload a file with file extension __shorter than 5 chars__!",
+                        delete_after=10.0,
+                    )
+
                 content = (
-                    "```py\n"
+                    f"```{filetype}\n"
                     + (await attach.read()).decode("u8").replace("`", "\u200b`")
                     + "```"
                 )
@@ -80,7 +88,7 @@ class ChallengeHandler(commands.Cog):
                     name=str(message.author), icon_url=message.author.avatar_url
                 )
                 embed.set_footer(
-                    text=f'#ID: {message.author.id} • {len(content)-9} chars • Filetype: {attach.filename.split(".")[-1]}'
+                    text=f"#ID: {message.author.id} • {len(content)-9} chars • Filetype: {filetype}"
                 )
                 await submission_channel.send(embed=embed)
 

--- a/cogs/challenges.py
+++ b/cogs/challenges.py
@@ -64,9 +64,9 @@ class ChallengeHandler(commands.Cog):
 
                 filetype = attach.filename.split(".")[-1]
 
-                if len(filetype) > 4:  # Most filetypes are 2-3 chars, 4 just to be safe
+                if len(filetype) > 4 or len(filetype) == 4:  # Most filetypes are 2-3 chars, 4 just to be safe
                     return await message.channel.send(
-                        "Please upload a file with file extension __shorter than 5 chars__!",
+                        "Please upload a file with a __non-empty file extension shorter than 5 chars__!",
                         delete_after=10.0,
                     )
 
@@ -88,7 +88,7 @@ class ChallengeHandler(commands.Cog):
                     name=str(message.author), icon_url=message.author.avatar_url
                 )
                 embed.set_footer(
-                    text=f"#ID: {message.author.id} • {len(content)-9} chars • Filetype: {filetype}"
+                    text=f"#ID: {message.author.id} • {len(content)-9} chars • Language: {filetype}"
                 )
                 await submission_channel.send(embed=embed)
 

--- a/cogs/challenges.py
+++ b/cogs/challenges.py
@@ -92,7 +92,7 @@ class ChallengeHandler(commands.Cog):
                     name=str(message.author), icon_url=message.author.avatar_url
                 )
                 embed.set_footer(
-                    text=f"#ID: {message.author.id} • {len(content)-9} chars • Language: {filetype} • Code Length: {len(code)}"
+                    text=f"#ID: {message.author.id} • {len(code)} chars • Language: {filetype}"
                 )
                 await submission_channel.send(embed=embed)
 

--- a/cogs/challenges.py
+++ b/cogs/challenges.py
@@ -35,17 +35,17 @@ class ChallengeHandler(commands.Cog):
     async def on_message(self, message):  # Submitted role.
 
         if message.channel.id in (680851820587122700, 713841306253656064):  # weekly
-            
+
             if message.author.id == self.bot.user.id:
                 return
-            
+
             if message.author.bot:
                 return await message.delete()
-            
-            if message.channel.id == 680851820587122700:  # weekly 1 
+
+            if message.channel.id == 680851820587122700:  # weekly 1
                 submitted = self.bot.guild.get_role(687417501931536478)
                 submission_channel = self.bot.guild.get_channel(729453161885990924)
-            
+
             else:  # weekly 2
                 submitted = self.bot.guild.get_role(715676464573317220)
                 submission_channel = self.bot.guild.get_channel(729453201081761862)
@@ -53,24 +53,39 @@ class ChallengeHandler(commands.Cog):
             if submitted not in message.author.roles:
                 await message.delete()
                 attach = message.attachments and message.attachments[0]
-                
+
                 if not attach:
-                    msg = f"{message.author.mention} make sure to __upload a " \
-                          f"python file__ that only includes the code required " \
-                          f"for the challenge!"
+                    msg = (
+                        f"{message.author.mention} make sure to __upload a "
+                        f"python file__ that only includes the code required "
+                        f"for the challenge!"
+                    )
                     return await message.channel.send(msg, delete_after=10.0)
-                
-                content = "```py\n" + (await attach.read()).decode("u8").replace("`", "\u200b`") + "```"
+
+                content = (
+                    "```py\n"
+                    + (await attach.read()).decode("u8").replace("`", "\u200b`")
+                    + "```"
+                )
                 if len(content) > 2040:
-                    msg = f"{message.author.mention} attachment can't be __more" \
-                          f" than 2040 characters__."
+                    msg = (
+                        f"{message.author.mention} attachment can't be __more"
+                        f" than 2040 characters__."
+                    )
                     return await message.channel.send(msg, delete_after=10.0)
 
                 await message.author.add_roles(submitted)
                 embed = discord.Embed(description=content, color=0x36393E)
-                embed.set_author(name=str(message.author), icon_url=message.author.avatar_url)
-                embed.set_footer(text=f'#ID: {message.author.id} • {len(content)-9} chars')
+                embed.set_author(
+                    name=str(message.author), icon_url=message.author.avatar_url
+                )
+                embed.set_footer(
+                    text=f'#ID: {message.author.id} • {len(content)-9} chars • Filetype: {attach.filename.split(".")[-1]}'
+                )
                 await submission_channel.send(embed=embed)
 
-        elif message.channel.id in [680851798340272141, 713841395965624490]:  # Automatic reaction
+        elif message.channel.id in [
+            680851798340272141,
+            713841395965624490,
+        ]:  # Automatic reaction
             await message.add_reaction("🖐️")

--- a/cogs/challenges.py
+++ b/cogs/challenges.py
@@ -66,7 +66,7 @@ class ChallengeHandler(commands.Cog):
 
                 if len(filetype) > 4 or len(filetype) == 0:  # Most filetypes are 2-3 chars, 4 just to be safe
                     return await message.channel.send(
-                        "Please upload a file with a __non-empty file extension shorter than 5 chars__!",
+                        f"{message.author.mention} attachement file extension must be between 1 and 4 characters long",
                         delete_after=10.0,
                     )
 
@@ -75,10 +75,13 @@ class ChallengeHandler(commands.Cog):
                     + (await attach.read()).decode("u8").replace("`", "\u200b`")
                     + "```"
                 )
-                if len(content) > 2040:
+                if len(content) > 4096 - (len(filetype) + 7):
+                    # 4096 = max embed description size
+                    # 7 = Length of ```\n```
+
                     msg = (
                         f"{message.author.mention} attachment can't be __more"
-                        f" than 2040 characters__."
+                        f" than {4096 - len(filetype) - 7} characters__."
                     )
                     return await message.channel.send(msg, delete_after=10.0)
 

--- a/cogs/challenges.py
+++ b/cogs/challenges.py
@@ -70,17 +70,18 @@ class ChallengeHandler(commands.Cog):
                         delete_after=10.0,
                     )
 
+                code = (await attach.read()).decode("u8")
+
                 content = (
                     f"```{filetype}\n"
-                    + (await attach.read()).decode("u8").replace("`", "\u200b`")
+                    + code.replace("`", "\u200b`")
                     + "```"
                 )
-                if len(content) > 4096 - (len(filetype) + 7):
+                if len(content) > 4096:
                     # 4096 = max embed description size
-                    # 7 = Length of ```\n```
 
                     msg = (
-                        f"{message.author.mention} attachment can't be __more"
+                        f"{message.author.mention} your submission can't be __more"
                         f" than {4096 - len(filetype) - 7} characters__."
                     )
                     return await message.channel.send(msg, delete_after=10.0)
@@ -91,7 +92,7 @@ class ChallengeHandler(commands.Cog):
                     name=str(message.author), icon_url=message.author.avatar_url
                 )
                 embed.set_footer(
-                    text=f"#ID: {message.author.id} • {len(content)-9} chars • Language: {filetype}"
+                    text=f"#ID: {message.author.id} • {len(content)-9} chars • Language: {filetype} • Code Length: {len(code)}"
                 )
                 await submission_channel.send(embed=embed)
 


### PR DESCRIPTION
I modified the challenges cog to include the filetype of the submitted file in the submission embeds. Lmk if I should change anything :smile: 

Also, I think my editor formatted a bunch of stuff in the same file with black, I can revert that/open a new pr if that's not wanted