### PR TITLE
K8s health check

### DIFF
--- a/bot/core.py
+++ b/bot/core.py
@@ -64,7 +64,7 @@ class DiscordBot(commands.Bot):
 
     async def on_ready(self):
         update_health("ready", True)
-    
+
     async def when_online(self):
         log.info("Waiting until bot is ready to load extensions and app commands.")
         await self.wait_until_ready()

--- a/bot/core.py
+++ b/bot/core.py
@@ -14,8 +14,8 @@ from bot.config import settings
 from bot.services import http, paste
 from bot.services.paste import Document
 from utils.errors import IgnorableException
-from utils.time import human_timedelta
 from utils.health import update_health
+from utils.time import human_timedelta
 
 log = logging.getLogger(__name__)
 

--- a/bot/core.py
+++ b/bot/core.py
@@ -15,6 +15,7 @@ from bot.services import http, paste
 from bot.services.paste import Document
 from utils.errors import IgnorableException
 from utils.time import human_timedelta
+from utils.health import update_health
 
 log = logging.getLogger(__name__)
 
@@ -52,10 +53,18 @@ class DiscordBot(commands.Bot):
         self.loop.create_task(self.when_online())
         self.presence.start()
 
+        update_health("running", True)
+
         self.tree.on_error = self.on_app_command_error
 
         self.error_webhook = discord.Webhook.from_url(url=settings.errors.webhook_url, session=http.session)
 
+    async def on_disconnect(self):
+        update_health("ready", False)
+
+    async def on_ready(self):
+        update_health("ready", True)
+    
     async def when_online(self):
         log.info("Waiting until bot is ready to load extensions and app commands.")
         await self.wait_until_ready()

--- a/utils/health.py
+++ b/utils/health.py
@@ -1,4 +1,10 @@
+import os
 
-def update_health(name: str, value):
-    with open(f'/tmp/.health.{name.lower()}', 'w') as f:
+def update_health(name: str, value: bool):
+    path = f'/tmp/.health.{name.lower()}'
+    
+    with open(path, 'w') as f:
         f.write(str(value))
+    # checking after to avoid making sure the file exists
+    if not value:
+        os.remove(path)

--- a/utils/health.py
+++ b/utils/health.py
@@ -1,9 +1,10 @@
 import os
 
+
 def update_health(name: str, value: bool):
-    path = f'/tmp/.health.{name.lower()}'
-    
-    with open(path, 'w') as f:
+    path = f"/tmp/.health.{name.lower()}"
+
+    with open(path, "w") as f:
         f.write(str(value))
     # checking after to avoid making sure the file exists
     if not value:

--- a/utils/health.py
+++ b/utils/health.py
@@ -1,0 +1,4 @@
+
+def update_health(name: str, value):
+    with open(f'/tmp/.health.{name.lower()}', 'w') as f:
+        f.write(str(value))


### PR DESCRIPTION
*Pull request for #231*
- Added k8s health check using a file based system `.health.ready`, `.health.running` stored on /tmp
### K8s Probes:

```yaml
readinessProbe:
  exec:
    command:
    - cat
    - /tmp/.health.ready  
  initialDelaySeconds: 15
  periodSeconds: 10
```
```yaml
livenessProbe:
  exec:
    command:
    - cat
    - /tmp/.health.running
  initialDelaySeconds: 15
  periodSeconds: 10
```
